### PR TITLE
Use namespace for dom parser

### DIFF
--- a/admin/class-wp-dev-dashboard-admin.php
+++ b/admin/class-wp-dev-dashboard-admin.php
@@ -1,4 +1,5 @@
 <?php
+use Sunra\PhpSimple\HtmlDomParser;
 
 /**
  * The dashboard-specific functionality of the plugin.
@@ -1006,7 +1007,7 @@ class WP_Dev_Dashboard_Admin {
 			return false;
 		}
 
-		$html = str_get_html( $html );
+		$html = HtmlDomParser::str_get_html( $html );
 
 		$table = $html->find( 'li[class=bbp-body]', 0 );
 


### PR DESCRIPTION
The new dom parser need to have it's namespace declare, otherwise a fatal error is thrown.
